### PR TITLE
feat: support ckbfs uri

### DIFF
--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -4,14 +4,22 @@ export type FileServerResult =
       content: string
       content_type: string
     }
+  | {
+      content: string
+      content_type: string
+      file_name: string
+    }
 
 export type BtcFsResult = FileServerResult
 export type IpfsResult = FileServerResult
+export type CkbFsResult = FileServerResult
 
 export type BtcFsURI = `btcfs://${string}`
 export type IpfsURI = `ipfs://${string}`
+export type CkbFsURI = `ckbfs://${string}`
 
 export type QueryBtcFsFn = (uri: BtcFsURI) => Promise<BtcFsResult>
+export type QueryCkbFsFn = (uri: CkbFsURI) => Promise<CkbFsResult>
 export type QueryIpfsFn = (uri: IpfsURI) => Promise<IpfsResult>
 export type QueryUrlFn = (uri: string) => Promise<FileServerResult>
 
@@ -23,7 +31,13 @@ export class Config {
     )
   }
 
-  private _queryUrlFn = async (url: string) => {   
+  private _queryCkbFsFn: QueryCkbFsFn = async (uri) => {
+    return fetch(
+      `https://ckbfs.nvap.app/api/v1/ckbfs/compatible?uri=${uri}`,
+    ).then((res) => res.json())
+  }
+
+  private _queryUrlFn = async (url: string) => {
     try {
       const response = await fetch(url)
       const blob = await response.blob()
@@ -76,6 +90,10 @@ export class Config {
 
   get queryUrlFn(): QueryUrlFn {
     return this._queryUrlFn
+  }
+
+  get queryCkbFsFn(): QueryCkbFsFn {
+    return this._queryCkbFsFn
   }
 }
 

--- a/packages/sdk/src/render-image-svg.ts
+++ b/packages/sdk/src/render-image-svg.ts
@@ -3,7 +3,7 @@ import type { ParsedTrait } from './traits-parser'
 import { config } from './config'
 import { backgroundColorParser } from './background-color-parser'
 import { processFileServerResult } from './utils/mime'
-import { isBtcFs, isIpfs } from './utils/string'
+import { isBtcFs, isCkbfs, isIpfs } from './utils/string'
 
 export async function renderImageSvg(traits: ParsedTrait[]): Promise<string> {
   const prevBg = traits.find((trait) => trait.name === 'prev.bg')
@@ -14,6 +14,9 @@ export async function renderImageSvg(traits: ParsedTrait[]): Promise<string> {
     if (isBtcFs(prevBg.value)) {
       const btcFsResult = await config.queryBtcFsFn(prevBg.value)
       bgImage = processFileServerResult(btcFsResult)
+    } else if (isCkbfs(prevBg.value)) {
+      const ckbfsResult = await config.queryCkbFsFn(prevBg.value)
+      bgImage = processFileServerResult(ckbfsResult)
     } else if (isIpfs(prevBg.value)) {
       const ipfsFsResult = await config.queryIpfsFn(prevBg.value)
       bgImage = processFileServerResult(ipfsFsResult)

--- a/packages/sdk/src/resolve-svg-traits.ts
+++ b/packages/sdk/src/resolve-svg-traits.ts
@@ -1,6 +1,6 @@
 import type { INode } from 'svgson'
 import { parse } from 'svgson'
-import type { BtcFsURI, IpfsURI } from './config'
+import type { BtcFsURI, IpfsURI, CkbFsURI } from './config'
 import { config } from './config'
 import { processFileServerResult } from './utils/mime'
 
@@ -15,16 +15,18 @@ async function handleNodeHref(node: INode) {
   }
   if ('href' in node.attributes) {
     const href = node.attributes.href
-    let result;
-    
+    let result
+
     if (href.startsWith('btcfs://')) {
       result = await config.queryBtcFsFn(node.attributes.href as BtcFsURI)
+    } else if (href.startsWith('ckbfs://')) {
+      result = await config.queryCkbFsFn(node.attributes.href as CkbFsURI)
     } else if (href.startsWith('ipfs://')) {
       result = await config.queryIpfsFn(node.attributes.href as IpfsURI)
     } else {
       result = await config.queryUrlFn(node.attributes.href as string)
     }
-    
+
     node.attributes.href = processFileServerResult(result)
   }
 

--- a/packages/sdk/src/utils/string.ts
+++ b/packages/sdk/src/utils/string.ts
@@ -1,4 +1,4 @@
-import type {BtcFsURI, IpfsURI} from '../config'
+import type { BtcFsURI, IpfsURI, CkbFsURI } from '../config'
 
 export function parseStringToArray(str: string): string[] {
   const regex = /'([^']*)'/g
@@ -22,6 +22,10 @@ export function isBtcFs(uri: string): uri is BtcFsURI {
 
 export function isIpfs(uri: string): uri is IpfsURI {
   return uri.startsWith('ipfs://')
+}
+
+export function isCkbfs(uri: string): uri is CkbFsURI {
+  return uri.startsWith('ckbfs://')
 }
 
 export function hexToBase64(hexstring: string): string {


### PR DESCRIPTION
This pull request introduces support for handling `ckbfs://` URIs in the SDK, just like how it deal with BTCFS URI links.

The server(https://ckbfs.nvap.app/api) is open-sourced in: https://github.com/nervape/ckbfs-server, as anyone can deploy a copy.

the api accepts different forms of CKBFS URIs

- TypeID based, which uses the CKBFS's TypeID as uri identifier: `ckbfs://bce89252cece632ef819943bed9cd0e2576f8ce26f9f02075b621b1c9a28056a`
- Transaction based, uses `ckbfs://{tx_hash}i{index}`： `ckbfs://431c9d668c1815d26eb4f7ac6256eb350ab351474daea8d588400146ab228780i0`


you can check a testnet example:
- https://test-ckbfs.nvap.app/api/v1/ckbfs/compatible?uri=ckbfs://431c9d668c1815d26eb4f7ac6256eb350ab351474daea8d588400146ab228780i0
- https://test-ckbfs.nvap.app/api/v1/ckbfs/compatible?uri=bce89252cece632ef819943bed9cd0e2576f8ce26f9f02075b621b1c9a28056a

or a mainnet example:
- https://ckbfs.nvap.app/api/v1/ckbfs/compatible?uri=59775e63f8ef8b3a1650fb1ddeea7801f1e7ac5d160282d3ad2c801445401b22i0
- https://ckbfs.nvap.app/api/v1/ckbfs/compatible?56831d51ab469eb7ee6551fd39e65caeff9b35569804a6532cf00f4c6f6e3d6a

And, you may want also check the non-compatible(with omiga's original api) version's output: https://ckbfs.nvap.app/api/v1/ckbfs?uri=ckbfs://56831d51ab469eb7ee6551fd39e65caeff9b35569804a6532cf00f4c6f6e3d6a